### PR TITLE
Add ability to send filenames and path to render file

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -4,22 +4,21 @@ const electron = window.require('electron');
 const remote = electron.remote;
 const ipc = electron.ipcRenderer
 const mainProcess = remote.require('./main.js');
-import ImageList from './ImageList';
-
+import ImageCard from './ImageCard.jsx';
 
 export default class App extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      images: ''
+      imgData: ''
     }
     this.screenshot = this.screenshot.bind(this)
-
+    this.imgData = this.imgData.bind(this)
   }
 
   componentWillMount() {
     ipc.on('imageList', (event, content) => {
-      this.setState({ images: content })
+      this.setState({ imgData: content })
     })
   }
 
@@ -28,15 +27,14 @@ export default class App extends Component {
   }
 
   render() {
-    console.log(this.state.images);
     return (
+      console.log(this.state.imgData)
       <div>
         <h1>Hey Gurl!</h1>
         <button onClick={this.screenshot}
                 className='btn'>
                 screenshot
         </button>
-        <ImageList />
       </div>
     )
   }

--- a/lib/components/ImageCard.jsx
+++ b/lib/components/ImageCard.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const ImageCard = (props) => {
+  return (
+    <div>
+      <h3>{props.imgName}</h3>
+    </div>
+  )
+}
+
+export default ImageCard;

--- a/lib/components/ImageList.js
+++ b/lib/components/ImageList.js
@@ -1,14 +1,26 @@
 import React, { Component } from 'react';
 
 export default class ImageList extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
   }
 
   render() {
+    let { imgData, path } = this.props
+
+    if(imgData) {
+      const images = imgData.map(img => {
+        console.log(img);
+        return (
+          <img src={path+img} />
+        )
+      })
+    }
+
+
     return (
       <div>
-        image list
+        {/* {!images ? '' : images } */}
       </div>
     )
   }

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 const Menubar = require('menubar');
+const webContents = electron.webContents;
 const mb = Menubar({
   width: 400,
   height: 500,
@@ -15,12 +16,42 @@ let mainWindow = null;
 
 mb.on('after-create-window', () => {
   mb.window.loadURL('file://' + __dirname + '/public/index.html');
+  mb.window.openDevTools();
 })
 
-mb.on('show', () => {
-  const content = 'stuff!'
-  mb.window.webContents.send('imageList', content)
+// app.on('ready', () => {
+//   console.log('ready!');
+//   app.send('imageList', 'yo!')
+// })
+
+// mb.on('show', () => {
+//   console.log('show');
+//   const pathToFile = app.getPath('desktop') + '/snip-it-images'
+//   const content = fs.readdir(pathToFile, (err, data) => {
+//     const package = {
+//       path: pathToFile,
+//       data: data
+//     }
+//     mb.window.webContents.send('imageList', package)
+//   })
+// })
+
+mb.on('ready', () => {
+  console.log('ready');
+  let package = 'hey'
+  const pathToFile = app.getPath('desktop') + '/snip-it-images'
+  fs.readdir(pathToFile, (err, data) => {
+    package = {
+      path: pathToFile,
+      data: data
+    }
+  })
+  mb.on('show', () => {
+    mb.window.webContents.send('imageList', package)
+
+  })
 })
+
 
 const enableScreenshot = () => {
   mb.window.hide();

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,3 +1,5 @@
+$sick-color: peru;
+
 body {
-  background-color: peru;
+  background-color: $sick-color;
 }


### PR DESCRIPTION
Add ImageCard component

Currently we only get state set to the correct data on the second mount. Tried every approach we could think of to get the data re-rendering once it comes through but nothing has worked. Need to consider pivoting the plan to just opening the current screenshot in a new window. 