### PR TITLE
Pivot ml

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -13,14 +13,13 @@ export default class App extends Component {
       imgData: ''
     }
     this.screenshot = this.screenshot.bind(this)
-    this.imgData = this.imgData.bind(this)
   }
 
-  componentWillMount() {
-    ipc.on('imageList', (event, content) => {
-      this.setState({ imgData: content })
-    })
-  }
+  // componentWillMount() {
+  //   ipc.on('imageList', (event, content) => {
+  //     this.setState({ imgData: content })
+  //   })
+  // }
 
   screenshot() {
     mainProcess.enableScreenshot()
@@ -28,7 +27,6 @@ export default class App extends Component {
 
   render() {
     return (
-      console.log(this.state.imgData)
       <div>
         <h1>Hey Gurl!</h1>
         <button onClick={this.screenshot}

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -15,24 +15,18 @@ export default class App extends Component {
     this.screenshot = this.screenshot.bind(this)
   }
 
-  // componentWillMount() {
-  //   ipc.on('imageList', (event, content) => {
-  //     this.setState({ imgData: content })
-  //   })
+  // screenshot() {
+  //   mainProcess.enableScreenshot()
   // }
-
-  screenshot() {
-    mainProcess.enableScreenshot()
-  }
 
   render() {
     return (
       <div>
         <h1>Hey Gurl!</h1>
-        <button onClick={this.screenshot}
+        {/* <button onClick={this.screenshot}
                 className='btn'>
                 screenshot
-        </button>
+        </button> */}
       </div>
     )
   }

--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -5,28 +5,48 @@ const remote = electron.remote;
 const ipc = electron.ipcRenderer
 const mainProcess = remote.require('./main.js');
 import ImageCard from './ImageCard.jsx';
+// import { SketchField, Tools } from 'react-sketch';
+import ReactPaint from 'react-paint';
 
 export default class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      imgData: ''
+      img: ''
     }
-    this.screenshot = this.screenshot.bind(this)
   }
 
-  // screenshot() {
-  //   mainProcess.enableScreenshot()
-  // }
+  componentWillMount() {
+    ipc.on('currentImg', (event, img) => {
+      console.log('img ', img);
+      this.setState({ img })
+    })
+  }
 
   render() {
+    console.log(this.state.img);
+    const props = {
+      style: {
+        background: 'tomato',
+      },
+      brushCol: '#ffffff',
+      lineWidth: 10,
+      className: 'react-paint',
+      height: 500,
+      width: 500
+    };
+
+
     return (
       <div>
         <h1>Hey Gurl!</h1>
-        {/* <button onClick={this.screenshot}
-                className='btn'>
-                screenshot
-        </button> */}
+        {/* <canvas width='200px' height='200px'></canvas> */}
+        {/* <SketchField height='300px'
+                     width='200px'
+                     tool={Tools.Pencil}
+                     color='black'
+                     lineWidth={3}/> */}
+        <ReactPaint {...props} />
       </div>
     )
   }

--- a/main.js
+++ b/main.js
@@ -13,32 +13,43 @@ const mb = Menubar({
 const screenshot = require('electron-screenshot-service');
 const shell = require('shelljs');
 
-let mainWindow = null;
+let editWindow = null;
 
 mb.on('after-show', () => {
-  mb.hideWindow()
   enableScreenshot();
   // mb.window.loadURL('file://' + __dirname + '/public/index.html');
   // mb.window.openDevTools();
 })
 
-const openNewImageFile = (file) => {
-  const filePath = app.getPath('desktop') + `/snip-it-images/${file}`
-  let newWindow = new BrowserWindow({ show: false });
-  fs.exists(filePath, (exists) => {
-    if(exists) {
-      newWindow.show()
-    }
-  })
-}
-
 const enableScreenshot = () => {
-  // mb.window.hide();
   const newImg = Date.now() + '.png'
   shell.exec('mkdir ~/Desktop/snip-it-images', { async: true })
   const sShot = shell.exec(`screencapture -i ~/Desktop/snip-it-images/${newImg}`, () => {
-    openNewImageFile(newImg)
+    openEditWindow(newImg)
   })
+}
+
+const openEditWindow = (file) => {
+  const filePath = app.getPath('desktop') + `/snip-it-images/${file}`
+  editWindow = new BrowserWindow({
+    show: false,
+    // backgroundColor: '#000',
+    title: 'Edit Screenshot',
+  });
+
+  fs.exists(filePath, (exists) => {
+    if(exists) {
+      editWindow.show()
+      editWindow.openDevTools();
+      editWindow.loadURL('file://' + __dirname + '/public/index.html')
+    }
+  })
+
+  editWindow.on('focus', () => {
+    console.log('show!');
+    editWindow.webContents.send('currentImg', filePath)
+  })
+
 }
 
 

--- a/main.js
+++ b/main.js
@@ -38,26 +38,38 @@ mb.on('after-create-window', () => {
 
 mb.on('ready', () => {
   console.log('ready');
-  let package = 'hey'
-  const pathToFile = app.getPath('desktop') + '/snip-it-images'
-  fs.readdir(pathToFile, (err, data) => {
-    package = {
-      path: pathToFile,
-      data: data
-    }
-  })
-  mb.on('show', () => {
-    mb.window.webContents.send('imageList', package)
-
-  })
+  // let package = 'hey'
+  // const pathToFile = app.getPath('desktop') + '/snip-it-images'
+  // fs.readdir(pathToFile, (err, data) => {
+  //   package = {
+  //     path: pathToFile,
+  //     data: data
+  //   }
+  // })
+  // mb.on('show', () => {
+  //   mb.window.webContents.send('imageList', package)
+  //
+  // })
 })
 
+const openNewImageFile = (file) => {
+  const filePath = app.getPath('desktop') + `/snip-it-images/${file}`
+  let newWindow = new BrowserWindow({ show: false });
+  fs.exists(filePath, (exists) => {
+    if(exists) {
+      console.log('exists!');
+      newWindow.show()
+    }
+  })
+}
 
 const enableScreenshot = () => {
   mb.window.hide();
-  const temp = Date.now()
+  const newImg = Date.now() + '.png'
   shell.exec('mkdir ~/Desktop/snip-it-images', { async: true })
-  shell.exec(`screencapture -i ~/Desktop/snip-it-images/${temp}.png`, { async: true })
+  const sShot = shell.exec(`screencapture -i ~/Desktop/snip-it-images/${newImg}`, () => {
+    openNewImageFile(newImg)
+  })
 }
 
 exports.enableScreenshot = enableScreenshot;

--- a/main.js
+++ b/main.js
@@ -5,51 +5,21 @@ const BrowserWindow = electron.BrowserWindow;
 const Menubar = require('menubar');
 const webContents = electron.webContents;
 const mb = Menubar({
-  width: 400,
-  height: 500,
-  icon: './snip-it-logo.png'
+  width: -1,
+  height: -1,
+  icon: './snip-it-logo.png',
+  tooltip: 'click to take a screenshot!'
 });
 const screenshot = require('electron-screenshot-service');
 const shell = require('shelljs');
 
 let mainWindow = null;
 
-mb.on('after-create-window', () => {
-  mb.window.loadURL('file://' + __dirname + '/public/index.html');
-  mb.window.openDevTools();
-})
-
-// app.on('ready', () => {
-//   console.log('ready!');
-//   app.send('imageList', 'yo!')
-// })
-
-// mb.on('show', () => {
-//   console.log('show');
-//   const pathToFile = app.getPath('desktop') + '/snip-it-images'
-//   const content = fs.readdir(pathToFile, (err, data) => {
-//     const package = {
-//       path: pathToFile,
-//       data: data
-//     }
-//     mb.window.webContents.send('imageList', package)
-//   })
-// })
-
-mb.on('ready', () => {
-  console.log('ready');
-  // let package = 'hey'
-  // const pathToFile = app.getPath('desktop') + '/snip-it-images'
-  // fs.readdir(pathToFile, (err, data) => {
-  //   package = {
-  //     path: pathToFile,
-  //     data: data
-  //   }
-  // })
-  // mb.on('show', () => {
-  //   mb.window.webContents.send('imageList', package)
-  //
-  // })
+mb.on('after-show', () => {
+  mb.hideWindow()
+  enableScreenshot();
+  // mb.window.loadURL('file://' + __dirname + '/public/index.html');
+  // mb.window.openDevTools();
 })
 
 const openNewImageFile = (file) => {
@@ -57,19 +27,19 @@ const openNewImageFile = (file) => {
   let newWindow = new BrowserWindow({ show: false });
   fs.exists(filePath, (exists) => {
     if(exists) {
-      console.log('exists!');
       newWindow.show()
     }
   })
 }
 
 const enableScreenshot = () => {
-  mb.window.hide();
+  // mb.window.hide();
   const newImg = Date.now() + '.png'
   shell.exec('mkdir ~/Desktop/snip-it-images', { async: true })
   const sShot = shell.exec(`screencapture -i ~/Desktop/snip-it-images/${newImg}`, () => {
     openNewImageFile(newImg)
   })
 }
+
 
 exports.enableScreenshot = enableScreenshot;

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
     "electron-screenshot-service": "^4.0.3",
     "img-loader": "^2.0.0",
     "menubar": "^5.2.3",
-    "react": "^0.14.7",
+    "react": "^0.14.8",
     "react-dom": "^0.14.3",
-    "shelljs": "^0.7.7"
+    "react-paint": "^1.0.1",
+    "react-sketch": "^0.3.2",
+    "shelljs": "^0.7.7",
+    "webpack": "^1.14.0"
   }
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -3,3 +3,11 @@ $sick-color: peru;
 body {
   background-color: $sick-color;
 }
+
+h1 {
+  color: white;
+}
+
+canvas {
+  background-color: white;
+}


### PR DESCRIPTION
@ejwill04 @bekahlundy 

### This latest PR includes a lot of changes. Here is a summary:

* Clicking icon on menubar engages screenshot without opening a window
* Once the screenshot is captured, a new window opens
* Current window features a React-Paint module instead of sketch because the sketch module prompted errors for offset width and offset height **(I think we can correct this in the source code)**
     * We _could_ create our own canvas with tools but doubt we will have time

### To Dos

* Transfer image from mainProcess to react file 
     * same issue we were having before exists, it sends the correct filename after a hot reload
* Add image to background of drawing tool/canvas

**Please review before either of you merge. If you prefer we can walk through it together before merging**
