### PR TITLE
Add ability to save drawing on canvas

### DIFF
--- a/lib/components/App.js
+++ b/lib/components/App.js
@@ -2,54 +2,64 @@ import React, { Component } from 'react';
 const fs = window.require('fs');
 const electron = window.require('electron');
 const remote = electron.remote;
-const ipc = electron.ipcRenderer
+const ipc = electron.ipcRenderer;
 const mainProcess = remote.require('./main.js');
 import ImageCard from './ImageCard.jsx';
-// import { SketchField, Tools } from 'react-sketch';
 import ReactPaint from 'react-paint';
+import FileSaver from 'FileSaver';
 
 export default class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      imgData: ''
+      imgData: '',
     }
+
+    this.saveFile = this.saveFile.bind(this);
   }
 
   componentDidMount() {
     ipc.send('mounted', 'mounted')
 
-    ipc.on('currentImg', (event, img) => {
-      console.log('img ', img);
-      this.setState({ img })
+    ipc.on('currentImg', (event, imgData) => {
+      this.setState({ imgData })
 
     })
   }
 
+  saveFile() {
+    const canvas = document.querySelector('canvas');
+    const file = canvas.toDataURL('image/png');
+
+  }
+
   render() {
+    const {imgData} = this.state
+
     const props = {
       style: {
-        backgroundImage: `url(${this.state.imgData.filePath})`,
+        backgroundImage: `url(${imgData.filePath})`,
         backgroundRepeat: 'no-repeat'
       },
       brushCol: '#ffffff',
       lineWidth: 3,
       className: 'react-paint',
-      height: this.state.imgData.height,
-      width: this.state.imgData.width
+      height: imgData.height,
+      width: imgData.width
     };
-
 
     return (
       <div>
-        <h1>Hey Gurl!</h1>
-        {/* <canvas width='200px' height='200px'></canvas> */}
-        {/* <SketchField height='300px'
-                     width='200px'
-                     tool={Tools.Pencil}
-                     color='black'
-                     lineWidth={3}/> */}
-        <ReactPaint {...props} />
+        <div className='buttons-container'>
+          <button className='btn'
+                  onClick={this.saveFile}>Save</button>
+          <button className='btn'>Undo</button>
+        </div>
+
+        <div className='canvas-container'>
+          <ReactPaint {...props} />
+        </div>
+
       </div>
     )
   }

--- a/main.js
+++ b/main.js
@@ -33,16 +33,20 @@ const enableScreenshot = () => {
 
 const openEditWindow = (file) => {
   const filePath = app.getPath('desktop') + `/snip-it-images/${file}`
-  let d = sizeOf(filePath)
+  const d = sizeOf(filePath)
+
   const imgData = {
     filePath,
     width: d.width,
     height: d.height
   }
+
   editWindow = new BrowserWindow({
     show: false,
     // backgroundColor: '#000',
     title: 'Edit Screenshot',
+    width: d.width + 50,
+    height: d.height + 100
   });
 
   fs.exists(filePath, (exists) => {
@@ -56,7 +60,7 @@ const openEditWindow = (file) => {
   editWindow.on('focus', () => {
     ipc.on('mounted', (event, response) => {
       if(response === 'mounted') {
-        editWindow.webContents.send('currentImg', filePath)
+        editWindow.webContents.send('currentImg', imgData)
       }
     })
 
@@ -64,5 +68,9 @@ const openEditWindow = (file) => {
 
 }
 
+const saveFile = (input) => {
+  console.log(input);
+}
 
 exports.enableScreenshot = enableScreenshot;
+exports.saveFile = saveFile

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "electron-rebuild": "./node_modules/.bin/electron-rebuild"
   },
   "dependencies": {
+    "FileSaver": "^0.10.0",
+    "electron-canvas-to-buffer": "^2.0.0",
     "electron-prebuilt": "^0.37.2",
     "electron-screenshot": "^1.0.4",
     "electron-screenshot-service": "^4.0.3",

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -11,3 +11,14 @@ h1 {
 canvas {
   background-color: white;
 }
+
+.canvas-container {
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.buttons-container {
+  display: flex;
+  flex-direction: row;
+}


### PR DESCRIPTION
Does not save image background. Three options I see are:

* Draw image onto canvas if possible by saving react-paint into our code base (otherwise npm i will overwrite changes in the node module code) and adding property to draw
* Create a new canvas behind the scenes that draws the image and save that file
* Use our own canvas to draw the image and create our own pen to write on it